### PR TITLE
Update T1115.yaml

### DIFF
--- a/atomics/T1115/T1115.md
+++ b/atomics/T1115/T1115.md
@@ -63,7 +63,7 @@ Utilize PowerShell to echo a command to clipboard and execute it
 
 ```powershell
 echo Get-Process | clip
-iex Get-Clipboard
+Get-Clipboard | iex
 ```
 
 

--- a/atomics/T1115/T1115.yaml
+++ b/atomics/T1115/T1115.yaml
@@ -29,4 +29,4 @@ atomic_tests:
     elevation_required: false
     command: |
       echo Get-Process | clip
-      iex Get-Clipboard
+      Get-Clipboard | iex


### PR DESCRIPTION
Update command for PowerShell so the contents of Get-Clipboard are actually invoked as an expression.

**Details:**
`iex Get-Clipboard` just executes the cmdlet `Get-Clipboard` which writes the value as string to console, it does not actual execute the contents as an expression. Instead, I changed this to pipe the output of Get-Clipboard to iex and that works as intended, minus an erroneous \r\n that echo adds but can be safely ignored. 

**Testing:**
Manual testing done locally on Windows 10 1909 with PowerShell v5 and PowerShell Core.

**Associated Issues:**
N/A